### PR TITLE
Dacade feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
-
+~/node_modules
 # build
 /out
 /dist

--- a/contract/assembly/index.ts
+++ b/contract/assembly/index.ts
@@ -9,7 +9,7 @@ const POST_SIZE: u32 = 16;
  * generate id when create new post
  * @returns id string
  */
-export function generatePostNumber(): string {
+ function generatePostNumber(): string {
   let buf = math.randomBuffer(POST_SIZE);
   let b64 = base64.encode(buf);
   return b64;


### PR DESCRIPTION
 

1.  Remove export `keyword` from `generatePostNumber` function.
    It should be an internal function and for security proposes only the necessary methods should be callable by another account.
2. Add node_modules to gitignore